### PR TITLE
fix: removed reload flag from uvicorn

### DIFF
--- a/backend/run.sh
+++ b/backend/run.sh
@@ -1,2 +1,2 @@
 # fastapi run.sh
-python3.9 -m uvicorn main:app --reload
+python3.9 -m uvicorn main:app


### PR DESCRIPTION
removed reload flag from unicorn as when manim scenes are rendered and saved the watcher detects a change in file-system and restarts the server